### PR TITLE
Made Move enum sortable

### DIFF
--- a/snakes/constants.py
+++ b/snakes/constants.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import auto, IntEnum
+from enum import auto, IntEnum, Enum
 
 import numpy as np
 
@@ -17,6 +17,7 @@ class Move(IntEnum):
     DOWN = auto()
     LEFT = auto()
     RIGHT = auto()
+    __str__ = Enum.__str__
 
 
 MOVES = (Move.UP, Move.DOWN, Move.LEFT, Move.RIGHT)

--- a/snakes/constants.py
+++ b/snakes/constants.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import Enum, auto
+from enum import auto, IntEnum
 
 import numpy as np
 
@@ -12,7 +12,7 @@ LEFT = np.array([-1, 0])
 RIGHT = np.array([1, 0])
 
 
-class Move(Enum):
+class Move(IntEnum):
     UP = auto()
     DOWN = auto()
     LEFT = auto()


### PR DESCRIPTION
Changed the Move Enum to type `IntEnum` so moves become sortable.

This is useful, for example, to match a move list to a reference moves ordering using sorting, like so:
```python
def match_moves(moves, move_ordering):
  return [x for _, x in sorted(zip(move_ordering, moves))]
```